### PR TITLE
HTML見た目修正、メール環境設定

### DIFF
--- a/app/views/layouts/_admin_menu.html.erb
+++ b/app/views/layouts/_admin_menu.html.erb
@@ -6,6 +6,6 @@
         <li><%= link_to 'メッセージ管理', managers_messages_path %></li>
         <li><%= link_to '収支管理', managers_account_path %></li>
         <li><%= link_to '通報アカウント管理', managers_report_path %></li>
-        <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "glyphicon glyphicon-log-out header-menu" %></li>
+        <li><%= link_to '', destroy_user_session_path, method: :delete, class: "fa fa-sign-out fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "ログアウト" %></li>
     </ul>
 </div><!-- /.navbar-collapse -->

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -9,10 +9,8 @@
                     </li>
                     <li>
                       <%= form_tag search_supporters_path, class: "navbar-form" do %>
-                        <div class="form-group">
-                          <input type="text" name="keyword" placeholder="先輩を検索" class="form-control">
-                          <button type="submit" class="btn btn-default">検索</button>
-                        </div>
+                        <input type="text" name="keyword" placeholder="先輩を検索" class="form-control">
+                        <button type="submit" class="btn btn-default">検索</button>
                       <% end %>
                     </li>
                   <% elsif current_user.user_type == 3 %>
@@ -24,27 +22,25 @@
                     </li>
                     <li>
                       <%= form_tag search_students_path, class: "navbar-form", method: :get do %>
-                        <div class="form-group">
-                          <input type="text" name="keyword" placeholder="生徒を検索" class="form-control">
-                          <button type="submit" class="btn btn-default">検索</button>
-                        </div>
+                        <input type="text" name="keyword" placeholder="生徒を検索" class="form-control">
+                        <button type="submit" class="btn btn-default">検索</button>
                       <% end %>
                     </li>
                   <% end %>
   
                   <% unless user_signed_in? %>
-                    <li style="color: #00a0e9 !important;"><%= link_to '>>ログイン', new_user_session_path, class: "header-menu" %></li>
-                    <li style="color: #00a0e9 !important;"><%= link_to '>>初めての方へ', new_user_registration_path, class: "header-menu" %></li>
+                    <li><%= link_to '', new_user_session_path, class: "fa fa-sign-in fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "ログイン" %></li>
+                    <li style="color: #00a0e9 !important;"><%= link_to '', new_user_registration_path, class: "fa fa-question-circle fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "初めての方へ" %></li>
                   <% else %>
-                    <li><%= link_to '|E|', events_path %></li>
-                    <li><%= link_to '|M|', messages_path %></li>
+                    <li><%= link_to '', events_path, class:"fa fa-newspaper-o fa-2x", data: {toggle: "tooltip", placement: "bottom" }, title: "新着情報" %></li>
+                    <li><%= link_to '', messages_path, class:"fa fa-comments-o fa-2x", data: {toggle: "tooltip", placement: "bottom" }, title: "メッセージ" %></li>
                     <li>
                       <%= link_to "#my_page_menu", class: "fancybox" do %>
                         マイページ
                         <span class="caret"></span>
                       <% end %>
                     </li>
-                    <li><%= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "glyphicon glyphicon-log-out header-menu" %></li>
+                    <li><%= link_to '', destroy_user_session_path, method: :delete, class: "fa fa-sign-out fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "ログアウト" %></li>
                   <% end %>
                 </ul>
               </div><!-- /.navbar-collapse -->

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -8,7 +8,7 @@
                       <% end %>
                     </li>
                     <li>
-                      <%= form_tag search_supporters_path, class: "navbar-form" do %>
+                      <%= form_tag search_supporters_path, class: "navbar-form", method: :get do %>
                         <input type="text" name="keyword" placeholder="先輩を検索" class="form-control">
                         <button type="submit" class="btn btn-default">検索</button>
                       <% end %>
@@ -29,8 +29,16 @@
                   <% end %>
   
                   <% unless user_signed_in? %>
-                    <li><%= link_to '', new_user_session_path, class: "fa fa-sign-in fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "ログイン" %></li>
-                    <li style="color: #00a0e9 !important;"><%= link_to '', new_user_registration_path, class: "fa fa-question-circle fa-2x header-menu", data: {toggle: "tooltip", placement: "bottom" }, title: "初めての方へ" %></li>
+                    <li>
+                      <%= form_tag new_user_session_path, class: "navbar-form", method: :get do %>
+                        <button type="submit" class="btn btn-default">ログイン</button>
+                      <% end %>
+                    </li>
+                    <li>
+                      <%= form_tag new_user_registration_path, class: "navbar-form", method: :get do %>
+                        <button type="submit" class="btn btn-default">新規会員登録</button>
+                      <% end %>
+                    </li>
                   <% else %>
                     <li><%= link_to '', events_path, class:"fa fa-newspaper-o fa-2x", data: {toggle: "tooltip", placement: "bottom" }, title: "新着情報" %></li>
                     <li><%= link_to '', messages_path, class:"fa fa-comments-o fa-2x", data: {toggle: "tooltip", placement: "bottom" }, title: "メッセージ" %></li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,17 +15,11 @@ Rails.application.configure do
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = true
-  # config.action_mailer.default_url_options = { host: 'https://clue-midwhite-1.c9users.io'}
-  config.action_mailer.default_url_options = { host: ENV['APP_DOMAIN']}
-  config.action_mailer.smtp_settings = {
-    :enable_starttls_auto => true,
-    :address => "smtp.gmail.com",
-    :port => 587,
-    :domain => 'smtp.gmail.com',
-    :user_name => ENV['GMAIL_ADDR'], #gmailアドレス
-    :password => ENV['GMAIL_PASS'], #gmailパスワード
-    :authentication => 'login',
-  }
+  config.host = ENV["C9_HOSTNAME"]
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = { :address => "localhost", :port => 1025 }
+  config.action_mailer.default_options = {from: "no-reply@#{config.host}"}
+  config.action_mailer.default_url_options = { host: config.host }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -14,6 +14,19 @@ Rails.application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
 
+  # Don't care if the mailer can't send.
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.default_url_options = { host: ENV['APP_DOMAIN']}
+  config.action_mailer.smtp_settings = {
+    :enable_starttls_auto => true,
+    :address => "smtp.gmail.com",
+    :port => 587,
+    :domain => 'smtp.gmail.com',
+    :user_name => ENV['GMAIL_ADDR'], #gmailアドレス
+    :password => ENV['GMAIL_PASS'], #gmailパスワード
+    :authentication => 'login',
+  }
+
   # Enable Rack::Cache to put a simple HTTP cache in front of your application
   # Add `rack-cache` to your Gemfile before enabling this.
   # For large-scale production use, consider using a caching reverse proxy like


### PR DESCRIPTION
**メニューバーの検索ボックスの上下のずれをそろえました**

**メール環境の設定を変えました**
各自のCloud9で .env 内容に以下の定義が無くても動作確認できるようになります。
APP_DOMAIN=xxx
GMAIL_ADDR=xxx
GMAIL_PASS=xxx
※本番／ステージングの場合、herokuの環境設定に上記環境変数を追加設定してください

※Cloud9上でのメール関連テストは、mail catcherを使います
設定：
gam install mailcatcher
サービス起動：
mailcatcher --http-ip $IP --http-port 8082
上記の準備までやっておきます。

自分のCloud9上で実行したメールを確認する時は、"https://プレビューのURL:8082" にアクセスします。

私たちが共通で使っているworkspaceの場合、以下のURLとなります：
https://clue-midwhite-1.c9users.io:8082/
