### PR TITLE
Bank data created by BULK INSERT.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,3 +35,5 @@ gem 'fancybox2-rails', '0.2.8'
 
 gem 'bootstrap-sass'
 gem 'font-awesome-rails', '~> 4.2'
+
+gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,8 @@ GEM
       activemodel (= 4.2.4)
       activesupport (= 4.2.4)
       arel (~> 6.0)
+    activerecord-import (0.11.0)
+      activerecord (>= 3.0)
     activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
@@ -222,6 +224,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import
   bootstrap-sass
   byebug
   coffee-rails (~> 4.1.0)
@@ -248,3 +251,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,17 +1,42 @@
 require 'csv'
 
+Bank.delete_all
+BankDatum.delete_all
+
+# Heroku の無料版MySQLは１時間に3200クエリという上限があるので、
+# 500レコードを一括で入れる
+banks = []
 CSV.foreach('db/bankdata.csv') do |row|
   if row[1].to_i == 0
-    Bank.create(bank_id: "#{row[0]}", store_id: row[1], name: row[3] ,name_kana: row[2])
+    banks << Bank.new(bank_id: "#{row[0]}", store_id: row[1], name: row[3] ,name_kana: row[2])
   end
+  
+  if banks.count % 500 == 0 && banks.count != 0
+    Bank.import banks
+    banks.clear
+  end
+end
+if banks.count > 0
+  Bank.import banks
+  banks.clear
 end
 
 bank_names = Bank.all
 
+bank_data = []
 CSV.foreach('db/bankdata.csv') do |row|
   unless row[1].to_i == 0
-    BankDatum.create(bank_id: "#{row[0]}", store_id: row[1], bank_name: bank_names.find_by(bank_id: row[0]).name ,bank_name_kana: bank_names.find_by(bank_id: row[0]).name_kana, store_name: row[3], store_name_kana: row[2])
+    bank_data << BankDatum.new(bank_id: "#{row[0]}", store_id: row[1], bank_name: bank_names.find_by(bank_id: row[0]).name ,bank_name_kana: bank_names.find_by(bank_id: row[0]).name_kana, store_name: row[3], store_name_kana: row[2])
   end
+    
+  if bank_data.count % 500 == 0 && bank_data.count != 0
+    BankDatum.import bank_data
+    bank_data.clear
+  end
+end
+if bank_data.count > 0
+  BankDatum.import bank_data
+  bank_data.clear
 end
 
 # bank_id: 銀行コード


### PR DESCRIPTION
Heroku の無料版MySQLは１時間に3200クエリという上限があるので、
銀行レコードは、500レコードを一括で入れるように変更しました。

新しく、gem 'activerecord-import' を追加しました。
bundle install をお願いします。
