### PR TITLE
管理者でないユーザーがダイレクトでリンクをたたくとページが見えてしまう

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -200,4 +200,11 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def before_manager_action
+    if user_signed_in?
+      unless current_user.user_type == 0
+        redirect_to root_path
+      end
+    end
+  end
 end

--- a/app/controllers/managers/events_controller.rb
+++ b/app/controllers/managers/events_controller.rb
@@ -1,6 +1,7 @@
 class Managers::EventsController < ApplicationController
   layout 'admin'
   before_action :authenticate_user!
+  before_action :before_manager_action
 
   add_breadcrumb '管理トップ', :managers_index_path
   add_breadcrumb '新着情報管理', nil, :only => [:index, :search, :show]

--- a/app/controllers/managers/messages_controller.rb
+++ b/app/controllers/managers/messages_controller.rb
@@ -1,6 +1,7 @@
 class Managers::MessagesController < ApplicationController
   layout 'admin'
   before_action :authenticate_user!
+  before_action :before_manager_action
 
   add_breadcrumb '管理トップ', :managers_index_path
   add_breadcrumb 'メッセージ管理', nil, :only => [:index, :search]

--- a/app/controllers/managers/reports_controller.rb
+++ b/app/controllers/managers/reports_controller.rb
@@ -1,6 +1,7 @@
 class Managers::ReportsController < ApplicationController
   layout 'admin'
   before_action :authenticate_user!
+  before_action :before_manager_action
 
   add_breadcrumb '管理トップ', :managers_index_path
   add_breadcrumb '通報アカウント管理', nil, :only => [:index, :search]

--- a/app/controllers/managers/users_controller.rb
+++ b/app/controllers/managers/users_controller.rb
@@ -2,6 +2,7 @@ class Managers::UsersController < ApplicationController
   layout 'admin'
   before_action :authenticate_user!
   before_action :set_user_type_params, :only => [:index, :search]
+  before_action :before_manager_action
 
   add_breadcrumb '管理トップ', :managers_index_path
   add_breadcrumb 'ユーザー管理', nil, :only => [:index, :search]


### PR DESCRIPTION
ユーザータイプが管理者(user_type=0)で無い場合、トップページへリダイレクトさせる処理を追加しました。

※当然ながら、ログインしていないユーザーがリンクをたたいた場合は、ログインページへ飛びます。
